### PR TITLE
feat: fallback to zlib when isal cannot be imported

### DIFF
--- a/src/aiohttp_isal/__init__.py
+++ b/src/aiohttp_isal/__init__.py
@@ -1,10 +1,19 @@
 __version__ = "0.2.0"
 
 import importlib
+import logging
 import zlib as zlib_original
 
 import aiohttp
-from isal import isal_zlib as best_zlib
+
+try:
+    from isal import isal_zlib as best_zlib
+
+    ISAL_AVAILABLE = True
+except ImportError:
+    ISAL_AVAILABLE = False
+
+_LOGGER = logging.getLogger(__name__)
 
 TARGETS = (
     "compression_utils",
@@ -19,6 +28,12 @@ TARGETS = (
 
 def enable_isal() -> None:
     """Enable isal."""
+    if not ISAL_AVAILABLE:
+        _LOGGER.warning(
+            "isal is not available, falling back to zlib, performance will be degraded."
+        )
+        return
+
     for location in TARGETS:
         try:
             importlib.import_module(f"aiohttp.{location}")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,5 @@
 import zlib as zlib_original
+from unittest.mock import patch
 
 import aiohttp.http_websocket
 from isal import isal_zlib as expected_zlib
@@ -16,3 +17,12 @@ def test_enable_disable():
     enable_isal()
     assert aiohttp.http_websocket.zlib is expected_zlib
     disable_isal()
+
+
+def test_isal_not_available():
+    """Test isal not available."""
+    with patch("aiohttp_isal.ISAL_AVAILABLE", False):
+        enable_isal()
+        assert aiohttp.http_websocket.zlib is zlib_original
+        disable_isal()
+        assert aiohttp.http_websocket.zlib is zlib_original


### PR DESCRIPTION
Since isal can be difficult for users to build when they are not using a supported Home Assistant image, fallback to zlib with a warning that performance will suffer